### PR TITLE
pass opts to Environment constructor

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,7 +18,7 @@ function compile(data, opts) {
 
 		var context = assign({}, data, file.data);
 		var filePath = file.path;
-		var env = (opts && opts.env) || new nunjucks.Environment(new nunjucks.FileSystemLoader(file.base));
+		var env = (opts && opts.env) || new nunjucks.Environment(new nunjucks.FileSystemLoader(file.base), opts);
 
 		try {
 			file.contents = new Buffer(env.renderString(file.contents.toString(), context));

--- a/index.js
+++ b/index.js
@@ -18,7 +18,7 @@ function compile(data, opts) {
 
 		var context = assign({}, data, file.data);
 		var filePath = file.path;
-		var env = new nunjucks.Environment(new nunjucks.FileSystemLoader(file.base), opts);
+		var env = (opts && opts.env) || new nunjucks.Environment(new nunjucks.FileSystemLoader(file.base), opts);
 
 		try {
 			file.contents = new Buffer(env.renderString(file.contents.toString(), context));

--- a/index.js
+++ b/index.js
@@ -18,7 +18,7 @@ function compile(data, opts) {
 
 		var context = assign({}, data, file.data);
 		var filePath = file.path;
-		var env = (opts && opts.env) || new nunjucks.Environment(new nunjucks.FileSystemLoader(file.base), opts);
+		var env = new nunjucks.Environment(new nunjucks.FileSystemLoader(file.base), opts);
 
 		try {
 			file.contents = new Buffer(env.renderString(file.contents.toString(), context));

--- a/readme.md
+++ b/readme.md
@@ -72,12 +72,9 @@ The data object used to populate the text.
 
 #### options
 
-##### options.env
+Type: `object`
 
-Type: `nunjucks.Environment`  
-Default: *`new nunjucks.Environment()`*
-
-The custom Nunjucks [Environment object](https://mozilla.github.io/nunjucks/api.html#environment) which will be used to compile templates.
+Options will be passed directly to Nunjucks [Environment object constructor](https://mozilla.github.io/nunjucks/api.html#constructor) which will be used to compile templates.
 
 ### nunjucks.precompile([options])
 

--- a/readme.md
+++ b/readme.md
@@ -76,6 +76,13 @@ Type: `object`
 
 Options will be passed directly to Nunjucks [Environment object constructor](https://mozilla.github.io/nunjucks/api.html#constructor) which will be used to compile templates.
 
+##### options.env
+
+Type: `nunjucks.Environment`  
+Default: *`new nunjucks.Environment()`*
+
+The custom Nunjucks [Environment object](https://mozilla.github.io/nunjucks/api.html#environment) which will be used to compile templates. If supplied, the rest of `options` will be ignored.
+
 ### nunjucks.precompile([options])
 
 Precompile a template for rendering dynamically at a later time.

--- a/test.js
+++ b/test.js
@@ -158,3 +158,16 @@ test.cb('support custom environment', t => {
 		contents: new Buffer('{{ message|shorten }}')
 	}));
 });
+
+test.cb('support custom environment options', t => {
+	const stream = fn.compile({message: '<span>Lorem ipsum</span>'}, {autoescape: false});
+
+	stream.on('data', file => {
+		t.is(file.contents.toString(), '<span>Lorem ipsum</span>');
+		t.end();
+	});
+
+	stream.write(new gutil.File({
+		contents: new Buffer('{{ message }}')
+	}));
+});


### PR DESCRIPTION
Wanted to modify some of the nunjucks Environment opts.  Was thinking this was a quick fix instead of needing to create and pass in a new Environment instance as options.env.