### PR TITLE
Update package.json to prevent issues with nunjucks on windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   ],
   "dependencies": {
     "gulp-util": "^3.0.0",
-    "nunjucks": "^2.2.0",
+    "nunjucks": "^2.2.0 <2.5.0",
     "object-assign": "^4.0.1",
     "through2": "^2.0.0"
   },


### PR DESCRIPTION
Since version 2.5.0 of nunjucks on windows, precompiled paths have been updated from Windows style (folder\sub-folder) to Unix style (folder/sub-folder). On big projects that used to be written with Windows style paths nunjucks will cause issues and forces the developer to set manually what version of nunjucks to use by npm shrinkwrap utility or by changing all paths to UNIX style.
Please release a specific version of gulp-nunjucks that include nunjucks ^2.5.0.