### PR TITLE
Fix for TypeError: First argument must be a string, Buffer, ArrayBuffer, Array, or array-like object. fixes #22

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,7 +20,7 @@ function compile(data, opts) {
 		const env = (opts && opts.env) || new nunjucks.Environment(new nunjucks.FileSystemLoader(file.base), opts);
 
 		env.renderString(file.contents.toString(), context, function (err, res) {
-			if (err) return this.emit('error', new util.PluginError('gulp-nunjucks', err, { fileName: filePath }));
+			if (err) return this.emit('error', new gutil.PluginError('gulp-nunjucks', err, { fileName: filePath }));
 			file.contents = Buffer.from(res || '');
 			this.push(file);
 			cb();

--- a/index.js
+++ b/index.js
@@ -20,7 +20,7 @@ function compile(data, opts) {
 		const env = (opts && opts.env) || new nunjucks.Environment(new nunjucks.FileSystemLoader(file.base), opts);
 
 		env.renderString(file.contents.toString(), context, function (err, res) {
-			if (err) return this.emit('error', new gutil.PluginError('gulp-nunjucks', err, { fileName: filePath }));
+			if (err) return cb(new gutil.PluginError('gulp-nunjucks', err, { fileName: filePath }));
 			file.contents = Buffer.from(res || '');
 			this.push(file);
 			cb();

--- a/index.js
+++ b/index.js
@@ -19,14 +19,12 @@ function compile(data, opts) {
 		const filePath = file.path;
 		const env = (opts && opts.env) || new nunjucks.Environment(new nunjucks.FileSystemLoader(file.base), opts);
 
-		try {
-			file.contents = Buffer.from(env.renderString(file.contents.toString(), context));
+		env.renderString(file.contents.toString(), context, function (err, res) {
+			if (err) return this.emit('error', new util.PluginError('gulp-nunjucks', err, { fileName: filePath }));
+			file.contents = Buffer.from(res || '');
 			this.push(file);
-		} catch (err) {
-			this.emit('error', new gutil.PluginError('gulp-nunjucks', err, {fileName: filePath}));
-		}
-
-		cb();
+			cb();
+		}.bind(this));
 	});
 }
 


### PR DESCRIPTION
Hi,

I fixed #22 by using the async version of renderString to catch/emit the error in the callback before its thrown. With this solution the gulp task will not stop on error - it will just show a message.

Greetings ,
Kolja Kutschera