### PR TITLE
Update extension by changing file path

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
 'use strict';
+const path = require('path');
 const through = require('through2');
 const nunjucks = require('nunjucks');
 const PluginError = require('plugin-error');
@@ -49,7 +50,7 @@ function precompile(opts) {
 		try {
 			options.name = (typeof options.name === 'function' && options.name(file)) || file.relative;
 			file.contents = Buffer.from(nunjucks.precompileString(file.contents.toString(), options));
-			file.extname = '.js';
+			file.path = path.join(path.dirname(file.path), path.basename(file.path, path.extname(file.path)) + '.js');
 			this.push(file);
 		} catch (err) {
 			this.emit('error', new PluginError('gulp-nunjucks', err, {fileName: filePath}));


### PR DESCRIPTION
setting `file.extname = '.js'` seems to only work on Vinyl file objects, meaning tests are passing but precompiling produces `.html` files when run on actual templates. Updating the file path using the Node `path` module works on all files.