### PR TITLE
chore: update nunjucks version to 3.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
 		"javascript"
 	],
 	"dependencies": {
-		"nunjucks": "^3.0.0",
+		"nunjucks": "^3.1.0",
 		"plugin-error": "^0.1.2",
 		"safe-buffer": "^5.1.1",
 		"through2": "^2.0.0"


### PR DESCRIPTION
resolves `fromIterator` error described in issue here:  https://github.com/mozilla/nunjucks/issues/1091